### PR TITLE
Feature: support window size for REMOTE CHROME-HEADLESS

### DIFF
--- a/lib/plugins/local_config.rb
+++ b/lib/plugins/local_config.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-def get_remote_capabilities(test_browser)
+def get_remote_capabilities(test_browser, window_size)
   if test_browser.eql? 'chrome_headless'
     return Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: { args: %w[headless disable-gpu] }
+      chromeOptions: { args: %W(headless disable-gpu window-size=#{window_size})}
     )
   end
   test_browser.to_sym
@@ -11,7 +11,9 @@ end
 
 Capybara.register_driver :wip do |app|
   test_browser = ENV['TEST_BROWSER'] || 'chrome'
+  window_size = ENV['TEST_WINDOW_SIZE'] || '1400x900'
   selenium_server = ENV['SELENIUM_SERVER']
+
   if selenium_server.nil?
     Capybara::Selenium::Driver.new(app, browser: test_browser.to_sym)
   else
@@ -19,7 +21,7 @@ Capybara.register_driver :wip do |app|
       app,
       browser: :remote,
       url: selenium_server,
-      desired_capabilities: get_remote_capabilities(test_browser)
+      desired_capabilities: get_remote_capabilities(test_browser, window_size)
     )
   end
 end


### PR DESCRIPTION
This PR allows use of custom `window_size` passed as `TEST_WINDOW_SIZE` env var.
* Default 1400x900
* Only work when using **remote** headless chrome