### PR TITLE
Cucumber 3.0

### DIFF
--- a/lib/env.rb
+++ b/lib/env.rb
@@ -7,7 +7,6 @@ require 'capybara/cucumber'
 require 'site_prism'
 require 'allure-cucumber'
 require 'rspec/expectations'
-require 'factory_girl'
 
 Capybara.default_max_wait_time = 10
 Capybara.save_path = 'screenshots/'
@@ -17,3 +16,11 @@ After do |_scenario|
 end
 
 Capybara.default_driver = :wip
+
+Cucumber::Core::Test::Step.module_eval do
+  def name
+    return text if self.text == 'Before hook'
+    return text if self.text == 'After hook'
+    "#{source.last.keyword}#{text}"
+  end
+end

--- a/lib/plugins/publish_reports.rb
+++ b/lib/plugins/publish_reports.rb
@@ -20,7 +20,7 @@ def pagerduty_payload(failed_length, reports_list_str)
 end
 
 AfterConfiguration do |config|
-  config.on_event :after_test_case do |event|
+  config.on_event :test_case_finished do |event|
     tests_failed.push(event.test_case.name) unless event.result.ok?
   end
 end

--- a/lib/plugins/screeshot_hooks.rb
+++ b/lib/plugins/screeshot_hooks.rb
@@ -6,9 +6,9 @@ class AllureCucumberDSLTemp
 end
 
 AfterConfiguration do |config|
-  config.on_event :after_test_step do |event|
+  config.on_event :test_step_finished do |event|
     if !ENV['DISABLE_REPORTS_SCREENSHOT'] && !event.result.ok?
-      filename = "#{event.test_case.name}/#{event.test_step.name}.png"
+      filename = "#{event.test_step.location.to_s}.png"
       Capybara.page.save_screenshot(filename)
       AllureCucumberDSLTemp.attach_file(
         filename,

--- a/lib/quintocumber.rb
+++ b/lib/quintocumber.rb
@@ -21,33 +21,9 @@ module Quintocumber
         end
         loader_file = File.join(File.dirname(__FILE__), '/loader.rb')
         args = default_args(loader_file) + @args
-        args.push("--format", "rerun", "--out", "failed.txt")
-
-        # TODO: Extract and improve this block
-        retry_attempts = 0
-        retry_attempts_idx = args.index("--retry")
-        if retry_attempts_idx
-            args.slice(retry_attempts_idx)
-            retry_attempts = args.slice(retry_attempts_idx + 1)
-            puts retry_attempts
-        end
-
-        begin 
-          Cucumber::Cli::Main.new(args, nil, @out, @err, @kernel).execute!
-        rescue SystemExit
-          i = 0
-          while i < retry_attempts.to_i
-            # TODO: Extract and improve this block
-            puts "Retry ##{i+1}"
-            args_to_retry = args.clone
-            args_to_retry + File.readlines("failed.txt")
-            begin
-              Cucumber::Cli::Main.new(args_to_retry, nil, @out, @err, @kernel).execute!
-            rescue SystemExit
-              i = i + 1
-            end
-          end
-        end
+        
+        runtime = Cucumber::Runtime.new 
+        Cucumber::Cli::Main.new(args, nil, @out, @err, @kernel).execute!(runtime)
       end
 
       def default_args(loader_file)

--- a/lib/quintocumber/version.rb
+++ b/lib/quintocumber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quintocumber
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/quintocumber.gemspec
+++ b/quintocumber.gemspec
@@ -33,13 +33,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.0.1'
   spec.add_development_dependency 'rubocop', '~> 0.49.1'
 
-  spec.add_dependency 'cucumber', '~> 2.4'
+  spec.add_dependency 'cucumber', '~> 3.0'
   spec.add_dependency 'rspec', '~> 3.6'
   spec.add_dependency 'site_prism', '~> 2.9'
   spec.add_dependency 'capybara', '~> 2.14'
   spec.add_dependency 'selenium-webdriver', '~> 3.13.0'
-  spec.add_dependency 'allure-cucumber', '~> 0.5'
-  spec.add_dependency 'factory_girl', '~> 4.8'
+  spec.add_dependency 'allure-cucumber', '~> 0.6.1'
+  
   spec.add_dependency 'faker', '~> 1.8'
   spec.add_dependency 'httparty', '~> 0.15'
   spec.add_dependency 'aws-sdk', '~> 2.10'


### PR DESCRIPTION
This PR updates *quintocumber* to use [cucumber 3.0](https://cucumber.io/blog/2017/09/27/announcing-cucumber-ruby-3-0-0).

Since cucumber 3.0 has breaking changes, we had to make small changes to work property, for a full migration guide, see [Upgrating to Cucumber 3.0](https://cucumber.io/blog/2017/09/27/announcing-cucumber-ruby-3-0-0)

What's new:
- [x]  quintocumber uses `retry` from cucumber, for more info check [living docs](https://app.cucumber.pro/projects/cucumber-ruby/documents/branch/master/features/docs/cli/retry_failing_tests.feature)
- [x] quintocumber exits with cucumber exit signal, so, if you have failing tests, quintocumber will exit with `1`
- [x] screenshots have the `step_test.location` as folder/filename, such as: `features/nice_tested_feature.feature.png`