### PR TITLE
Config for chrome41 Browserstack

### DIFF
--- a/lib/plugins/browserstack.yml
+++ b/lib/plugins/browserstack.yml
@@ -12,3 +12,10 @@ browser_caps:
     os: OS X
     os_version: El Capitan
     resolution: 1600x1200
+  chrome41:
+    browser: chrome
+    version: 41
+    os: windows
+    os_version: 10
+    resolution: 1366x768
+    browserstack.selenium_version: 2.46.0


### PR DESCRIPTION
## Chrome41 config
This PR adds basic config to run tests on chrome 41 on browserstack

## Why
Chrome 41 is the current browser used on Google bot for crawling and indexing, there a lot of functionalities including native JavaScript functions that isn't supported by this browser. It may cause malfunctioning and therefore ruin your SEO. 
