### PR TITLE
Enabling use of local Browserstack with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following environment variables allow you to you to configure the appllicati
 | ------------- | ------------- |
 | BROWSERSTACK_USERNAME | username for Browserstack account  |
 | BROWSERSTACK_ACCESS_KEY | access key for Browserstack account |
+| BROWSERSTACK_LOCAL | uses local Browserstack if set to `true` |
 | SLACK_WEBHOOK_URL | webhook for slack notifications |
 | REPORT_BUCKET | s3 bucket to save allure reports |
 | PAGERDUTY_ROUTING_KEY | pager duty Events Api v2 integration key |
@@ -48,6 +49,12 @@ To release a new version run `bump patch`, which will create a git tag and commi
 To generate a new gem, now run `gem build quintocumber.gemspec`.
 
 Push the `.gem` file to [rubygems.org](https://rubygems.org) using `gem push quintocumber-<NEW_VERSION_TAG>.gem`
+
+## Using Browserstack locally
+You may want to run tests on Browserstack against a local version or on a protected envirionment. ([More use cases](https://www.browserstack.com/local-testing#configuration))
+You'll need:
+1. Set env vars `BROWSERSTACK_LOCAL=true` and `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`
+2. Have the [local binary running](https://www.browserstack.com/local-testing#command-line)
 
 ## Contributing
 

--- a/lib/plugins/browserstack_config.rb
+++ b/lib/plugins/browserstack_config.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'capybara/cucumber'
+require 'logger'
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::DEBUG
 
 # Get browserstack configuration from browserstack.yml
 # and override credentials if credentials are set in env variables
@@ -42,6 +46,11 @@ if browserstack_config['user'] && browserstack_config['key']
     browserstack_config['common_caps'] = browserstack_config['common_caps'] ||
                                          {}
 
+    # Using local browserstack according to env var
+    if ENV['BROWSERSTACK_LOCAL'] && ENV['BROWSERSTACK_LOCAL'].to_s  == 'true'
+      browserstack_config['common_caps']['browserstack.local'] = true
+    end
+
     @caps = browserstack_config['common_caps'].merge(
       browserstack_config['browser_caps'][TEST_BROWSER]
     )
@@ -52,7 +61,8 @@ if browserstack_config['user'] && browserstack_config['key']
     # sets project name
     @caps['project'] = PROJECT_NAME
 
-    # all set, instanciate new remote broser
+    logger.info("Instanciate new remote browser with desired caps: %s" % @caps)
+    # all set, instanciate new remote browser
     Capybara::Selenium::Driver.new(
       app,
       browser: :remote,

--- a/quintocumber.gemspec
+++ b/quintocumber.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capybara', '~> 2.14'
   spec.add_dependency 'selenium-webdriver', '~> 3.13.0'
   spec.add_dependency 'allure-cucumber', '~> 0.6.1'
+  spec.add_dependency 'logger'
   
   spec.add_dependency 'faker', '~> 1.8'
   spec.add_dependency 'httparty', '~> 0.15'


### PR DESCRIPTION
## What
This PR enable use of BrowserStack runining loca, this is useful for testing on local or protected environment. Such as http://localhost:8080 or https://test.yoursite.com

To work, you need to have the correct binary of the local Browserstack running, you may follow instructions at
https://www.browserstack.com/local-testing#configuration